### PR TITLE
Use switch instead of checkout in empty repo template

### DIFF
--- a/templates/repo/empty.tmpl
+++ b/templates/repo/empty.tmpl
@@ -51,7 +51,7 @@
 								<div class="markup">
 									<pre><code>touch README.md
 git init
-{{if ne .Repository.DefaultBranch "master"}}git checkout -b {{.Repository.DefaultBranch}}{{end}}
+{{if ne .Repository.DefaultBranch "master"}}git switch -c {{.Repository.DefaultBranch}}{{end}}
 git add README.md
 git commit -m "first commit"
 git remote add origin <span class="js-clone-url">{{$.CloneButtonOriginLink.HTTPS}}</span>


### PR DESCRIPTION
Idea is to use recommended git command in the template.